### PR TITLE
Allow ^C Quit to Better fit Conventions

### DIFF
--- a/src/bin/firework/main.rs
+++ b/src/bin/firework/main.rs
@@ -94,7 +94,7 @@ fn main() -> Result<()> {
         if event::poll(Duration::ZERO)? {
             match event::read()? {
                 event::Event::Key(e) => {
-                    if e.code == KeyCode::Esc {
+                    if e.code == KeyCode::Esc || (e.code == KeyCode::Char('c') && e.modifiers.contains(event::KeyModifiers::CONTROL)) {
                         is_running = false;
                     }
                 }


### PR DESCRIPTION
Most command line programs support ^C quit, so hopefully this would be helpful for user experience. It's just a simple single-line change.